### PR TITLE
fix: Add showtime validation with LocalDateTime to prevent booking pa…

### DIFF
--- a/src/main/java/com/trainning/movie_booking_system/service/impl/BookingServiceImpl.java
+++ b/src/main/java/com/trainning/movie_booking_system/service/impl/BookingServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +79,7 @@ public class BookingServiceImpl implements BookingService {
         // ===== 2. Validate showtime exists =====
         Showtime showtime = showtimeRepository.findById(request.getShowtimeId())
                 .orElseThrow(() -> new NotFoundException("Showtime not found with ID: " + request.getShowtimeId()));
+        validateShowTime(showtime);
 
         // ===== 3. Verify seats are held by current user (pre-check) =====
         seatClient.assertHeldByUser(request.getShowtimeId(), request.getSeatIds(), userId);
@@ -243,5 +245,46 @@ public class BookingServiceImpl implements BookingService {
         // TODO: Add filters (by user, by showtime, by status, by date range)
         
         throw new UnsupportedOperationException("Pagination not yet implemented");
+    }
+
+    // ========== PRIVATE METHODS ========== //
+    
+    /**
+     * Validate showtime chưa bắt đầu và còn thời gian đặt vé
+     * 
+     * @param showtime Showtime cần validate
+     * @throws BadRequestException nếu showtime đã qua hoặc vượt cutoff time
+     */
+    private void validateShowTime(Showtime showtime) {
+        LocalDateTime now = LocalDateTime.now();
+        
+        // Combine show_date + start_time thành LocalDateTime
+        LocalDateTime showtimeStart = LocalDateTime.of(
+            showtime.getShowDate(),
+            showtime.getStartTime()
+        );
+        
+        // Rule 1: Không được book suất chiếu đã qua
+        if (showtimeStart.isBefore(now)) {
+            log.warn("Attempt to book past showtime: showtimeId={}, showtimeStart={}, now={}", 
+                    showtime.getId(), showtimeStart, now);
+            throw new BadRequestException(
+                String.format("Cannot book for past showtime. Showtime was at %s", 
+                    showtimeStart)
+            );
+        }
+        
+        // Rule 2: Đóng booking 15 phút trước giờ chiếu
+        LocalDateTime cutoffTime = showtimeStart.minusMinutes(15);
+        if (now.isAfter(cutoffTime)) {
+            log.warn("Attempt to book within cutoff time: showtimeId={}, cutoffTime={}, now={}", 
+                    showtime.getId(), cutoffTime, now);
+            throw new BadRequestException(
+                String.format("Booking closes 15 minutes before showtime. Cutoff time was %s", 
+                    cutoffTime)
+            );
+        }
+        
+        log.debug("Showtime validation passed for showtime ID: {}", showtime.getId());
     }
 }


### PR DESCRIPTION
…st showtimes

WHAT CHANGED:
- Added validateShowTime() method in BookingServiceImpl
- Validates showtime hasn't started (past showtime check)
- Validates booking within 15-minute cutoff window
- Uses LocalDateTime for accurate date+time comparison
- Added comprehensive logging with warn level

WHY:
- Users could book tickets for past showtimes
- No validation for showtime start time
- Business rule: booking closes 15 minutes before showtime
- Previous attempt used LocalTime (time-only) which caused false negatives

HOW IT WORKS:
- Combines showDate + startTime into LocalDateTime
- Compares full datetime (not just time)
- Rule 1: Reject if showtime already started
- Rule 2: Reject if within 15-minute cutoff window

TESTING:
- Code compiles successfully
- Ready for unit tests and manual testing

Fixes: BUG #1 - Showtime Validation
Related: TASK_BUG_1_SHOWTIME_VALIDATION.md, BUGS_TO_FIX.md